### PR TITLE
Final push before release

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,7 @@
 # API
 
 ### [Input data for RecurrenceMicrostatesAnalysis.jl](@id input_data)
+
 **RecurrenceMicrostatesAnalysis.jl** accepts three types of input, each associated with a different backend:
 - [`StateSpaceSet`](@ref) or `Vector{<:Real}`: used for multivariate time series, datasets, or state-space representations.
 - `AbstractArray{<:Real}`: used for spatial data, enabling RMA to be applied within the generalized framework of Spatial Recurrence Plots (SRP) [Marwan2007Spatial](@cite). We give some examples about its use in [Spatial data](@ref).
@@ -14,7 +15,8 @@ StateSpaceSet
 ```
 
 ### [Output data from RecurrenceMicrostatesAnalysis.jl](@id output_data)
-When computing the RMA distribution, **RecurrenceMicrostatesAnalysis.jl** returns a [`Probabilities`](@ref).
+
+When computing the RMA distribution, **RecurrenceMicrostatesAnalysis.jl** returns a [`Probabilities`](@ref) or [`Counts`](@ref).
 This type is provided by **ComplexityMeasures.jl**, allowing this package to interoperate naturally with its tools and workflows.
 
 ```@docs
@@ -23,11 +25,13 @@ Counts
 ```
 
 ## Recurrence Microstates
+
 ```@docs
 RecurrenceMicrostates
 ```
 
 ### Recurrence expressions
+
 ```@docs
 RecurrenceExpression
 recurrence
@@ -36,6 +40,7 @@ CorridorRecurrence
 ```
 
 ### Microstate shapes
+
 ```@docs
 MicrostateShape
 RectMicrostate
@@ -44,6 +49,7 @@ TriangleMicrostate
 ```
 
 ### Sampling modes
+
 ```@docs
 SamplingMode
 SRandom
@@ -51,16 +57,18 @@ Full
 ```
 
 ### Sampling space
+
 !!! todo "Future implementation"
     We pretend to expand the [`RecurrenceMicrostates`](@ref) structure to also consider
     a setted space from the recurrence plot as source of information to construct
     the RMA distribution.
-    
+
 ```@docs
 SamplingSpace
 ```
 
 ## Recurrence Quantification Analysis
+
 ```@docs
 RecurrenceRate
 RecurrenceDeterminism
@@ -72,6 +80,7 @@ rma
 ```
 
 ## Optimization
+
 ```@docs
 Parameter
 optimize
@@ -79,6 +88,7 @@ Threshold
 ```
 
 ## Operations
+
 ```@docs
 Operation
 operate

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,17 +4,17 @@
 RecurrenceMicrostatesAnalysis
 ```
 
-!!! info "Citation and credit"
-    If you find this package useful, please consider giving it a star on GitHub and don't forget to cite [our work](https://doi.org/10.1063/5.0293708). 😉
-
 ##  Latest news
-- Integration with **DynamicalSystems.jl** and **ComplexityMeasures.jl**.
-- See the **CHANGELOG.md** (at the GitHub repo) for more!
+
+- **RecurrenceMicrostateAnalysis.jl** is now integrated into **DynamicalSystems.jl**.
+- Realizing that RMA are complexity measures, the API of **RecurrenceMicrostateAnalysis.jl** has been updated to inherit and extend from **ComplexityMeasures.jl**.
+- Brand new comprehensive tutorial.
+
+You can always see the **CHANGELOG.md** (at the GitHub repo) for more!
 
 ##  Getting started
-Start by reviewing about [input](@ref input_data) and [output](@ref output_data) used by 
-**RecurrenceMicrostatesAnalysis.jl**. Next, you can explore the
-[tutorial](@ref tutorial) for a basic introduction to using the package.
+
+Start by reviewing the [tutorial](@ref tutorial) for a basic introduction to using the package.
 You can also consult individual functions in the [API](@ref), and find applied examples in the
 dedicated [Examples](@ref) section.
 

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -7,7 +7,7 @@
 
 # !!! info "ComplexityMeasures.jl"
 #     RecurrenceMicrostatesAnalysis.jl interfaces with, and extends, ComplexityMeasures.jl.
-#     It can enhance your understanding if you have first view the [tutorial of ComplexityMeasures.jl](https://juliadynamics.github.io/DynamicalSystemsDocs.jl/complexitymeasures/stable/tutorial/). 
+#     It can enhance your understanding if you have first view the [tutorial of ComplexityMeasures.jl](https://juliadynamics.github.io/DynamicalSystemsDocs.jl/complexitymeasures/stable/tutorial/).
 #     Regardless the current tutorial is written to be self-contained.
 
 # ## Crash-course into RMA
@@ -48,7 +48,7 @@
 # is done via the ComplexityMeasures.jl interface and it is relatively straightforward.
 # We first specify the options of [`RecurrenceMicrostates`](@ref),
 # which essentially means e.g., what sort of distance threshold defines a recurrence,
-# and what is maximum microstate size to consider. Then we pass this to functions
+# and what maximum microstate size to consider. Then we pass this to functions
 # like `probabilities`, `entropy`, etc.
 
 # Let's first generate some data of a chaotic map using **DynamicalSystems.jl**:
@@ -71,7 +71,7 @@ X
 
 # Notice that `X` is already a [`StateSpaceSet`](@ref). Because  **RecurrenceMicrostatesAnalysis.jl**
 # is part of **DynamicalSystems.jl**, this data type is the preferred input type.
-# Other types are also possible as we described in the [API](@ref).
+# Other types are also possible as we described in the [API](@ref input_data).
 
 # Now, we specify the recurrence microstate configuration
 
@@ -231,7 +231,7 @@ lines(wd)
 # in the maximum observable disorder. Moreover, when working with RMA and
 # machine learning (see [this example](@ref example_ml)),
 # in most cases there is a correlation between the accuracy and the distribution
-# that maximizes the recurrence entropy [Spezzatto2024ML](@cite). Thus, it is a good 
+# that maximizes the recurrence entropy [Spezzatto2024ML](@cite). Thus, it is a good
 # idea to use this as a basis for defining an optimal value for the recurrence threshold.
 
 # With this in mind, we provide a function to optimize some [`Parameter`](@ref)
@@ -279,7 +279,7 @@ probabilities(rmspace, X)
 # **RecurrenceMicrostateAnalysis.jl** supports several configurations for the recurrence outcome space
 # while leveraging the same backend (see [`RecurrenceMicrostates`](@ref)).
 # If you want to contribute with new recurrence expressions, microstate shapes, or sampling modes,
-# read the section [for devs](@ref devs) and open an 
+# read the section [for devs](@ref devs) and open an
 # [issue](https://github.com/JuliaDynamics/RecurrenceMicrostatesAnalysis.jl/issues)
 # if you encounter any difficulties 🙂
 
@@ -359,7 +359,7 @@ entropy(Shannon(), probs)
 # Note that if you are using a grayscale image, you need to use an
 # `Array` with size `(1, H, W)`. The first dimension stores the
 # features of the data, which are used to compute the recurrences,
-# i.e., $\vec{x}_{\vec{i}}$. The same principle must be applied 
+# i.e., $\vec{x}_{\vec{i}}$. The same principle must be applied
 # to other types of spatial data.
 
 # ##   GPU
@@ -407,7 +407,7 @@ entropy(Shannon(), probs)
 #    4  0.0016157228214197196
 #    5  0.039249842118455266
 #    6  0.014588514785254093
-#    ⋮  
+#    ⋮
 #  507  0.0001702340127557486
 #  508  0.0006545307752488948
 #  509  0.00010442086328848504
@@ -499,7 +499,7 @@ using BenchmarkTools
 #  Time  (median):     1.600 s              ┊ GC (median):    26.32%
 #  Time  (mean ± σ):   1.620 s ± 70.701 ms  ┊ GC (mean ± σ):  25.31% ±  4.59%
 
-#   █ █                    █                                █  
+#   █ █                    █                                █
 #   █▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
 #   1.56 s         Histogram: frequency by time        1.72 s <
 
@@ -516,7 +516,7 @@ using BenchmarkTools
 #  Time  (median):     1.931 s              ┊ GC (median):    28.42%
 #  Time  (mean ± σ):   1.913 s ± 52.274 ms  ┊ GC (mean ± σ):  26.94% ±  3.07%
 
-#   █                                          █            █  
+#   █                                          █            █
 #   █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
 #   1.85 s         Histogram: frequency by time        1.95 s <
 
@@ -536,7 +536,7 @@ using BenchmarkTools
 #  Time  (median):     194.991 ms               ┊ GC (median):    19.28%
 #  Time  (mean ± σ):   194.819 ms ±  49.483 ms  ┊ GC (mean ± σ):  31.77% ± 23.86%
 
-#   ▁           ▁ ▁▁▁▁ █▁ ▁   █▁ █▁▁ ▁█   █    ▁  ▁    ▁        ▁  
+#   ▁           ▁ ▁▁▁▁ █▁ ▁   █▁ █▁▁ ▁█   █    ▁  ▁    ▁        ▁
 #   █▁▁▁▁▁▁▁▁▁▁▁█▁████▁██▁█▁▁▁██▁███▁██▁▁▁█▁▁▁▁█▁▁█▁▁▁▁█▁▁▁▁▁▁▁▁█ ▁
 #   88 ms            Histogram: frequency by time          316 ms <
 
@@ -553,7 +553,7 @@ using BenchmarkTools
 #  Time  (median):     324.494 ms               ┊ GC (median):    22.84%
 #  Time  (mean ± σ):   325.391 ms ±  35.346 ms  ┊ GC (mean ± σ):  21.35% ± 14.70%
 
-#   █         █  █        ███  █  ███ █ █   █               █ █ █  
+#   █         █  █        ███  █  ███ █ █   █               █ █ █
 #   █▁▁▁▁▁▁▁▁▁█▁▁█▁▁▁▁▁▁▁▁███▁▁█▁▁███▁█▁█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁█▁█ ▁
 #   260 ms           Histogram: frequency by time          387 ms <
 
@@ -575,7 +575,7 @@ using BenchmarkTools
 #  Time  (median):     259.462 ms               ┊ GC (median):     6.82%
 #  Time  (mean ± σ):   274.213 ms ±  34.593 ms  ┊ GC (mean ± σ):  16.25% ± 11.64%
 
-#   █                                                              
+#   █
 #   █▅█▅▁▁▁▁▁▁▁▁▁▁▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▁▅███▁▁▁▁▁▅ ▁
 #   239 ms           Histogram: frequency by time          319 ms <
 
@@ -592,7 +592,7 @@ using BenchmarkTools
 #  Time  (median):     319.407 ms               ┊ GC (median):    1.60%
 #  Time  (mean ± σ):   322.378 ms ±  73.731 ms  ┊ GC (mean ± σ):  8.72% ± 10.56%
 
-#   █▁  ▁▁▁▁             ▁▁▁     ▁         ▁ ▁   ▁        ▁     ▁  
+#   █▁  ▁▁▁▁             ▁▁▁     ▁         ▁ ▁   ▁        ▁     ▁
 #   ██▁▁████▁▁▁▁▁▁▁▁▁▁▁▁▁███▁▁▁▁▁█▁▁▁▁▁▁▁▁▁█▁█▁▁▁█▁▁▁▁▁▁▁▁█▁▁▁▁▁█ ▁
 #   240 ms           Histogram: frequency by time          460 ms <
 

--- a/src/core/recurrence_microstates.jl
+++ b/src/core/recurrence_microstates.jl
@@ -6,8 +6,7 @@ export RecurrenceMicrostates
 """
     RecurrenceMicrostates <: CountBasedOutcomeSpace
 
-It defines an `OutcomeSpace` from **ComplexityMeasures.jl**, representing a recurrence microstate
-outcome space.
+An `OutcomeSpace` from **ComplexityMeasures.jl** representing recurrence microstates.
 
 ## Description
 
@@ -34,30 +33,33 @@ This matrix is known as a recurrence microstate [Corso2018Entropy](@cite) of len
 a local portion of the recurrence plot \$\\mathbf{R}(\\mathscr{X}, \\mathscr{X})\$.
 
 ## Implementation
+
 To define a recurrence microstate, three components are required:
 1. The recurrence function, \$r_{(i,j)}\$, used to compute recurrences (see [`RecurrenceExpression`](@ref)).
 2. The microstate shape and its size (see [`MicrostateShape`](@ref)).
 3. The method used to extract microstates from \$\\mathscr{X}\$ (see [`SamplingMode`](@ref)).
 
 ## Constructors
+
 ```julia
 RecurrenceMicrostates(expr::RecurrenceExpression, shape::MicrostateShape; kwargs...)
 RecurrenceMicrostates(expr::RecurrenceExpression, N::Int; kwargs...) # It uses square microstates.
 ```
 
-- Using [`ThresholdRecurrence`](@ref):
+Using [`ThresholdRecurrence`](@ref):
 ```julia
 RecurrenceMicrostates(ε::Real, N::Int; kwargs...)
 RecurrenceMicrostates(ε::Real, shape::MicrostateShape; kwargs...)
 ```
 
-- Using [`CorridorRecurrence`](@ref):
+Using [`CorridorRecurrence`](@ref):
 ```julia
 RecurrenceMicrostates(ε_min::Real, ε_max::Real, N::Int; kwargs...)
 RecurrenceMicrostates(ε_min::Real, ε_max::Real, shape::MicrostateShape; kwargs...)
 ```
 
 ## Spatial generalization
+
 We also implement a spatial generalization of recurrence microstate analysis based on [Marwan2007Spatial](@cite).
 It operates similarly to standard RMA, but retrieves microstates from a recurrence tensor constructed
 from the data (without explicitly constructing the full tensor). **This is an experimental feature included
@@ -91,6 +93,7 @@ Moreover, since RQA is defined differently for spatial recurrence plots, the imp
     Some shapes and sampling modes are not compatible with the spatial generalization, e.g. [`TriangleMicrostate`](@ref) and [`Full`](@ref).
 
 ### Spatial constructors
+
 These constructors use a hypergeometric version of [`RectMicrostate`](@ref), defined by an `NTuple` called `structure`.
 
 ```julia
@@ -100,7 +103,9 @@ RecurrenceMicrostates(ε_min::Real, ε_max::Real, structure::NTuple; kwargs...)
 ```
 
 ## Keyword arguments
-- `metric::Metric`: The metric used to compute recurrence.
+- `metric`: The metric used to compute distances between points. Typically it is a
+  subtype of `Metric` but it can be an arbitrary function of two points returning a real.
+  In the case of using GPUs, this must be an instance of [`GPUMetric`](@ref).
 - `ratio`: The sampling ratio. The default is `0.1`.
 - `sampling`: The sampling mode. The default is [`SRandom`](@ref).
 
@@ -110,9 +115,7 @@ RecurrenceMicrostates(ε_min::Real, ε_max::Real, structure::NTuple; kwargs...)
     This means that as the number of entries increases, the memory required to
     store the full distribution quickly becomes impractical. For example, a square
     \$6 \\times 6\$ microstate has 36 entries, resulting in \$2^{36} = 68,719,476,736\$
-    possible microstates. As another example, a 4-dimensional hypercubic microstate
-    with side length 3 has \$3^4 = 81\$ entries, leading to \$2^{81} \\approx 2.42 \\times 10^{24}\$
-    possible microstates. Clearly, allocating memory for such distributions is not feasible.
+    possible microstates.
 
 """
 struct RecurrenceMicrostates{MS <: MicrostateShape, RE <: RecurrenceExpression, SM <: SamplingMode} <: ComplexityMeasures.CountBasedOutcomeSpace
@@ -133,13 +136,13 @@ function RecurrenceMicrostates(expr::RecurrenceExpression, N::Int; ratio::Real =
     return RecurrenceMicrostates(shape, expr, sampling)
 end
 ##########################################################################################
-function RecurrenceMicrostates(ε::Real, N::Int; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric::Metric = DEFAULT_METRIC)
+function RecurrenceMicrostates(ε::Real, N::Int; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC)
     shape = RectMicrostate(N)
     expr = ThresholdRecurrence(ε; metric = metric)
     return RecurrenceMicrostates(shape, expr, sampling)
 end
 
-function RecurrenceMicrostates(ε::Real, shape::MicrostateShape; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric::Metric = DEFAULT_METRIC)
+function RecurrenceMicrostates(ε::Real, shape::MicrostateShape; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC)
     expr = ThresholdRecurrence(ε; metric = metric)
     return RecurrenceMicrostates(shape, expr, sampling)
 end

--- a/src/rqa/disorder.jl
+++ b/src/rqa/disorder.jl
@@ -9,7 +9,7 @@ export Disorder, WindowedDisorder
 # Computed by maximizing the `PartialDisorder`.
 #
 # - `PartialDisorder`: it is an internal definition, which computes the entropy associated
-# wit disorder for an specific threshold. It is computed using the disorder for all 
+# wit disorder for an specific threshold. It is computed using the disorder for all
 # classes, which are computed using `ClassPartialDisorder`.
 #
 # - `ClassPartialDisorder`: it is the entropy quantity associated with disorder for an
@@ -86,20 +86,20 @@ This estimator is equivalent to [`Disorder`](@ref), but computes it by splitting
 length `W`, returning a vector of measured disorder values for each window.
 
 ## Keyword arguments
-- `metric::Metric`: The metric used to compute recurrence.
+- `metric`: The metric used to compute recurrence.
 - `threshold_range::Int`: The number of threshold values used to estimate disorder.
 - `step::Int`: The step between windows. The default is `W`.
 """
-struct WindowedDisorder{W, N} <: ComplexityEstimator
+struct WindowedDisorder{W, N, M} <: ComplexityEstimator
     labels::Vector{Vector{Int}}
-    metric::Metric
+    metric::M # Typically metric
     threshold_range::Int
     win_step::Int
 end
 
-struct PartialDisorder{N} <: ComplexityEstimator
+struct PartialDisorder{N, RM <: RecurrenceMicrostates} <: ComplexityEstimator
     labels::Vector{Vector{Int}}
-    rmspace::RecurrenceMicrostates
+    rmspace::RM
 end
 
 struct ClassPartialDisorder <: ComplexityEstimator
@@ -108,7 +108,7 @@ struct ClassPartialDisorder <: ComplexityEstimator
 end
 
 function complexity(
-        c::Disorder{N}, 
+        c::Disorder{N},
         x::Union{StateSpaceSet, Vector{<:Real}, <:AbstractGPUVector{<:SVector}}
     ) where {N}
 
@@ -145,7 +145,7 @@ function complexity(
     ) where {N, W}
 
     windowed_data = [ StateSpaceSet(x[(i + 1):(i + W)]) for i ∈ 0:c.win_step:(size(x, 1) - W) ]
-    
+
     #   We need to define the threshold range here.
     s = ceil(Int, length(windowed_data) * 0.1)
     opt_ths = zeros(Float64, s)
@@ -175,7 +175,7 @@ function complexity(
     for j ∈ eachindex(th_range)
         rmspace = RecurrenceMicrostates(th_range[j], N; sampling = Full(), metric = c.metric)
         partial = PartialDisorder{N}(c.labels, rmspace)
-        
+
         for i ∈ eachindex(windowed_data)
             ξ[i, j] = complexity(partial, windowed_data[i])
         end
@@ -234,7 +234,7 @@ function complexity(
     for j ∈ eachindex(th_range)
         rmspace = RecurrenceMicrostates(th_range[j], N; sampling = Full(), metric = c.metric)
         partial = PartialDisorder{N}(c.labels, rmspace)
-        
+
         for i ∈ eachindex(windowed_gpu)
             ξ[i, j] = complexity(partial, windowed_gpu[i])
         end
@@ -244,7 +244,7 @@ function complexity(
 end
 
 function complexity(
-        c::PartialDisorder{N}, 
+        c::PartialDisorder{N},
         x::Union{<: StateSpaceSet{D}, <:AbstractGPUVector{<: SVector{D}}}
     ) where {N, D}
 
@@ -260,7 +260,7 @@ function complexity(
 end
 
 function complexity(
-        c::ClassPartialDisorder, 
+        c::ClassPartialDisorder,
         x::Union{StateSpaceSet, <:AbstractGPUVector{<:SVector}}
     )
     probs = probabilities(c.rmspace, x)
@@ -280,7 +280,7 @@ ClassPartialDisorder(rexpr::RecurrenceExpression, c::Int, N::Int = 4) = ClassPar
 # outcome space, using a given probability distribution that was computed from this
 # outcome space.
 
-# This function works for [`DiagonalMicrostate`](@ref) with length 3, 
+# This function works for [`DiagonalMicrostate`](@ref) with length 3,
 # or \$3 \\times 3\$ [`RectMicrostate`](@ref). Any other input will returns an error.
 ##########################################################################################
 function measure(c::ClassPartialDisorder, probs::Probabilities)
@@ -358,7 +358,7 @@ function compute_labels(N::Int; S = collect(permutations(1:N)))
 
         #   Compute transposes
         for label in copy(labels[end])
-            
+
             #   Transpose the label
             microstate = operate(transposition, label)
 


### PR DESCRIPTION
Gabriel, I've noticed the following: in some struct definitions, fields are contained in abstract types. For example,

```julia
struct ClassPartialDisorder <: ComplexityEstimator
    labels::Vector{Int}
    rmspace::RecurrenceMicrostates
end
```

here the field `rmspace` is an abstract type. The better way to do this is to have a type parameter:

```julia
struct ClassPartialDisorder{RM<: RecurrenceMicrostates} <: ComplexityEstimator
    labels::Vector{Int}
    rmspace::RM
end
```

The reason is, julia can make poor optimization choices for abstract types, and also compiling them is slower. 

Do you mind going over this PR and changing this in the source code when you find it?