### PR TITLE
Add sampling space settings to RecurrenceMicrostates outcome space

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -58,13 +58,11 @@ Full
 
 ### Sampling space
 
-!!! todo "Future implementation"
-    We pretend to expand the [`RecurrenceMicrostates`](@ref) structure to also consider
-    a setted space from the recurrence plot as source of information to construct
-    the RMA distribution.
-
 ```@docs
-SamplingSpace
+AbstractSamplingSpace
+RectSamplingSpace
+TriangleSamplingSpace
+ColumnSamplingSpace
 ```
 
 ## Recurrence Quantification Analysis

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -97,23 +97,44 @@ X = randn(1000)
 probabilities(rmspace, X)
 ```
 
+## Adding a new Sampling Space
+
+### Steps
+1. Define the sampling space shape: from which region microstates are sampled.
+2. Define a new struct that is a subtype of [`AbstractSamplingSpace`](@ref). It is used to initialize
+    a sampling space; being it user interface.
+3. Internally, you need to also define a new struct that is a subtype of `InternalSamplingSpace`, or
+    use some of the currently implemented. The [`AbstractSamplingSpace`](@ref) is independent of a
+    time-series, and (as the name say) is the abstract definition of the sampling space. When we
+    call the function `histogram` to compute the recurrence microstates distribution given an input,
+    this abstract sampling space is combinated with the input to define the definitivly sampling space,
+    that is a `InternalSamplingSpace`.
+4. Define how this [`AbstractSamplingSpace`](@ref) is converted to a `InternalSamplingSpace` for each
+    [`MicrostateShape`](@ref), implementing a overload to `SamplingSpace` function.
+5. If you had defined a new `InternalSamplingSpace`, you also must define how this `InternalSamplingSpace`
+    is used by a sampling mode, writting a `get_num_samples` and a `get_sample` function.
+6. Add a docstring to your sampling space describring it.
+7. Add your sampling space to `docs/src/api.md`.
+8. Add the expression to the [`AbstractSamplingSpace`](@ref) docstring.
+9. Add tests to `test/distributions.jl` and `test/sampling.jl`.
+
 ## Adding a new Sampling Mode
 
 ### Steps
 
-1. Define how the sampling mode operates: which microstates are sampled, from which regions, and in what quantity.
-    The [`SamplingSpace`](@ref) must be taken into account when designing the sampling logic.
+1. Define how the sampling mode operates: which microstates are sampled, and in what quantity.
+    The [`AbstractSamplingSpace`](@ref) must be taken into account when designing the sampling logic.
 2. Define a new struct that is a subtype of [`SamplingMode`](@ref). The struct may be empty (e.g., [`Full`](@ref)) or
     contain parameters such as a sampling ratio (e.g., [`SRandom`](@ref)).
-3. Implement the dispatch `get_num_samples(mode::YourType, ::SamplingSpace)`, which determines the number of samples
+3. Implement the dispatch `get_num_samples(mode::YourType, ::InternalSamplingSpace)`, which determines the number of samples
     to be drawn given the sampling mode and the sampling space.
-4. Implement the dispatch `get_sample(::RMACore, ::YourType, space::SamplingSpace, rng, m)`, which returns the starting
+4. Implement the dispatch `get_sample(::RMACore, ::YourType, space::InternalSamplingSpace, rng, m)`, which returns the starting
     pair $(i, j)$ to construct the microstate. Here, `RMACore` defines whether it is running on the CPU or GPU, `rng` is
     a random number generator, and `m` is a counter of microstates.
 5. Add a docstring to your sampling mode describing its behavior and initialization.
 6. Add your sampling mode to `docs/src/api.md`.
 7. Add the expression to the [`SamplingMode`](@ref) docstring.
-8. Add tests to `test/distributions.jl` and `test/sampling.jl`.
+8. Add tests to `test/distributions.jl`.
 
 ## Adding a new Microstate Shape
 
@@ -129,7 +150,7 @@ probabilities(rmspace, X)
     read the microstate as an integer.
 5. Implement the dispatch `get_offsets(::RMACore, ::MyShape)`, which returns which positions are accessed from $(i, j)$
     to construct the microstate.
-6. Define how your shape reacts to a [`SamplingSpace`](@ref) by implementing `SamplingSpace(::MyType, x, y)`.
+6. Define how your shape reacts to a [`AbstractSamplingSpace`](@ref) by implementing `SamplingSpace(::MyType, x, y)`.
 7. Add a docstring to your microstate shape describing its behavior and initialization.
 8. Add your microstate shape to `docs/src/api.md`.
 9. Add the expression to the [`MicrostateShape`](@ref) docstring.
@@ -194,7 +215,8 @@ Now, we just need to define how our microstate will behave with respect to a sam
 for all available sampling spaces, but you need to do so for at least one of them.
 ```@example dev
 RecurrenceMicrostatesAnalysis.SamplingSpace(
-    ::MyMicrostateShape, 
+    ::MyMicrostateShape,
+    ::RectSamplingSpace,
     x::StateSpaceSet, 
     y::StateSpaceSet
 ) = RecurrenceMicrostatesAnalysis.SSRect2(length(x) - 2, length(y) - 2)

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -273,7 +273,8 @@ complexity(partial, X)
 expr = CorridorRecurrence(0.05, 0.27)
 shape = TriangleMicrostate(3)
 sampling = Full()
-rmspace = RecurrenceMicrostates(expr, shape; sampling)
+space = TriangleSamplingSpace()
+rmspace = RecurrenceMicrostates(expr, shape; sampling, space)
 probabilities(rmspace, X)
 
 # **RecurrenceMicrostateAnalysis.jl** supports several configurations for the recurrence outcome space

--- a/src/core/cpu_core.jl
+++ b/src/core/cpu_core.jl
@@ -34,11 +34,11 @@ end
 #.........................................................................................
 
 function histogram(
-    rmspace::RecurrenceMicrostates{MS, RE, SM},
+    rmspace::RecurrenceMicrostates{MS, RE, SM, SS},
     x::Union{StateSpaceSet, Vector{<: Real}},
     y::Union{StateSpaceSet, Vector{<: Real}} = x;
     threads::Int = 0
-) where {MS <: MicrostateShape, RE <: RecurrenceExpression, SM <: SamplingMode}
+) where {MS <: MicrostateShape, RE <: RecurrenceExpression, SM <: SamplingMode, SS <: AbstractSamplingSpace}
 
     #   Threads, input and core
     threads = threads <= 0 ? Threads.nthreads() : threads
@@ -47,7 +47,7 @@ function histogram(
     core = CPUCore()
 
     #   Info
-    space = SamplingSpace(rmspace.shape, x_input, y_input)
+    space = SamplingSpace(rmspace.shape, rmspace.space, x_input, y_input)
     samples = get_num_samples(rmspace.sampling, space)
 
     #   Allocate memory
@@ -83,17 +83,17 @@ end
 #   Based on spatial data: (CPU only)
 #.........................................................................................
 function histogram(
-    rmspace::RecurrenceMicrostates{MS, RE, SM},
+    rmspace::RecurrenceMicrostates{MS, RE, SM, SS},
     x::AbstractArray{<: Real},
     y::AbstractArray{<: Real} = x;
     threads::Int = 0
-) where {MS <: MicrostateShape, RE <: RecurrenceExpression, SM <: SamplingMode}
+) where {MS <: MicrostateShape, RE <: RecurrenceExpression, SM <: SamplingMode, SS <: AbstractSamplingSpace}
     #   Core and threads
     threads = threads <= 0 ? Threads.nthreads() : threads
     core = CPUCore()
 
     #   Info
-    space = SamplingSpace(rmspace.shape, x, y)
+    space = SamplingSpace(rmspace.shape, rmspace.space, x, y)
     samples = get_num_samples(rmspace.sampling, space)
     dim_x = ndims(x) - 1
     dim_y = ndims(y) - 1

--- a/src/core/gpu/gpu_core.jl
+++ b/src/core/gpu/gpu_core.jl
@@ -25,18 +25,18 @@ end
 #   Based on time series: (GPU)
 #.........................................................................................
 function histogram(
-    rmspace::RecurrenceMicrostates{MS, <: RecurrenceExpression{T, M}, SM},
+    rmspace::RecurrenceMicrostates{MS, <: RecurrenceExpression{T, M}, SM, SS},
     x::AbstractGPUVector{SVector{N, T}},
     y::AbstractGPUVector{SVector{N, T}} = x;
     groupsize::Int = 256
-) where {MS <: MicrostateShape, SM <: SamplingMode, N, T <: Real, M <: GPUMetric}
+) where {MS <: MicrostateShape, SM <: SamplingMode, SS <: AbstractSamplingSpace, N, T <: Real, M <: GPUMetric}
 
     #   Get backend.
     backend = KernelAbstractions.get_backend(x)
     core = GPUCore()
 
     #   Info
-    space = SamplingSpace(rmspace.shape, x, y)
+    space = SamplingSpace(rmspace.shape, rmspace.space, x, y)
     samples = get_num_samples(rmspace.sampling, space)
 
     #   Allocate memory

--- a/src/core/recurrence_microstates.jl
+++ b/src/core/recurrence_microstates.jl
@@ -34,10 +34,11 @@ a local portion of the recurrence plot \$\\mathbf{R}(\\mathscr{X}, \\mathscr{X})
 
 ## Implementation
 
-To define a recurrence microstate, three components are required:
+To define a recurrence microstate, four components are required:
 1. The recurrence function, \$r_{(i,j)}\$, used to compute recurrences (see [`RecurrenceExpression`](@ref)).
 2. The microstate shape and its size (see [`MicrostateShape`](@ref)).
 3. The method used to extract microstates from \$\\mathscr{X}\$ (see [`SamplingMode`](@ref)).
+4. The segment of a trajectory from where each index \$i\$ or \$j\$ can be extracted.
 
 ## Constructors
 
@@ -108,6 +109,7 @@ RecurrenceMicrostates(ε_min::Real, ε_max::Real, structure::NTuple; kwargs...)
   In the case of using GPUs, this must be an instance of [`GPUMetric`](@ref).
 - `ratio`: The sampling ratio. The default is `0.1`.
 - `sampling`: The sampling mode. The default is [`SRandom`](@ref).
+- `space`: The sampling space. The default is [`RectSamplingSpace`](@ref).
 
 !!! warning "Memory"
     Note that the number of possible microstates is \$2^\\sigma\$, where
@@ -118,64 +120,65 @@ RecurrenceMicrostates(ε_min::Real, ε_max::Real, structure::NTuple; kwargs...)
     possible microstates.
 
 """
-struct RecurrenceMicrostates{MS <: MicrostateShape, RE <: RecurrenceExpression, SM <: SamplingMode} <: ComplexityMeasures.CountBasedOutcomeSpace
+struct RecurrenceMicrostates{MS <: MicrostateShape, RE <: RecurrenceExpression, SM <: SamplingMode, SS <: AbstractSamplingSpace} <: ComplexityMeasures.CountBasedOutcomeSpace
     shape::MS
     expr::RE
     sampling::SM
+    space::SS
 end
 
 ##########################################################################################
 #   Recurrence Microstate: Convenience constructors
 ##########################################################################################
-function RecurrenceMicrostates(expr::RecurrenceExpression, shape::MicrostateShape; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio))
-    return RecurrenceMicrostates(shape, expr, sampling)
+function RecurrenceMicrostates(expr::RecurrenceExpression, shape::MicrostateShape; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), space::AbstractSamplingSpace = RectSamplingSpace())
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 
-function RecurrenceMicrostates(expr::RecurrenceExpression, N::Int; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio))
+function RecurrenceMicrostates(expr::RecurrenceExpression, N::Int; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), space::AbstractSamplingSpace = RectSamplingSpace())
     shape = RectMicrostate(N)
-    return RecurrenceMicrostates(shape, expr, sampling)
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 ##########################################################################################
-function RecurrenceMicrostates(ε::Real, N::Int; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC)
+function RecurrenceMicrostates(ε::Real, N::Int; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC, space::AbstractSamplingSpace = RectSamplingSpace())
     shape = RectMicrostate(N)
     expr = ThresholdRecurrence(ε; metric = metric)
-    return RecurrenceMicrostates(shape, expr, sampling)
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 
-function RecurrenceMicrostates(ε::Real, shape::MicrostateShape; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC)
+function RecurrenceMicrostates(ε::Real, shape::MicrostateShape; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC, space::AbstractSamplingSpace = RectSamplingSpace())
     expr = ThresholdRecurrence(ε; metric = metric)
-    return RecurrenceMicrostates(shape, expr, sampling)
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 
 ##########################################################################################
-function RecurrenceMicrostates(ε_min::Real, ε_max::Real, N::Int; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC)
+function RecurrenceMicrostates(ε_min::Real, ε_max::Real, N::Int; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC, space::AbstractSamplingSpace = RectSamplingSpace())
     shape = RectMicrostate(N)
     expr = CorridorRecurrence(ε_min, ε_max; metric = metric)
-    return RecurrenceMicrostates(shape, expr, sampling)
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 
-function RecurrenceMicrostates(ε_min::Real, ε_max::Real, shape::MicrostateShape; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC)
+function RecurrenceMicrostates(ε_min::Real, ε_max::Real, shape::MicrostateShape; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC, space::AbstractSamplingSpace = RectSamplingSpace())
     expr = CorridorRecurrence(ε_min, ε_max; metric = metric)
-    return RecurrenceMicrostates(shape, expr, sampling)
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 ##########################################################################################
-function RecurrenceMicrostates(expr::RecurrenceExpression, structure::NTuple; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio))
+function RecurrenceMicrostates(expr::RecurrenceExpression, structure::NTuple; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), space::AbstractSamplingSpace = RectSamplingSpace())
     shape = RectMicrostate(structure)
-    return RecurrenceMicrostates(shape, expr, sampling)
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 
 ##########################################################################################
-function RecurrenceMicrostates(ε::Real, structure::NTuple; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC)
+function RecurrenceMicrostates(ε::Real, structure::NTuple; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC, space::AbstractSamplingSpace = RectSamplingSpace())
     shape = RectMicrostate(structure)
     expr = ThresholdRecurrence(ε; metric = metric)
-    return RecurrenceMicrostates(shape, expr, sampling)
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 
 ##########################################################################################
-function RecurrenceMicrostates(ε_min::Real, ε_max::Real, structure::NTuple; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC)
+function RecurrenceMicrostates(ε_min::Real, ε_max::Real, structure::NTuple; ratio::Real = 0.05, sampling::SamplingMode = SRandom(ratio), metric = DEFAULT_METRIC, space::AbstractSamplingSpace = RectSamplingSpace())
     shape = RectMicrostate(structure)
     expr = CorridorRecurrence(ε_min, ε_max; metric = metric)
-    return RecurrenceMicrostates(shape, expr, sampling)
+    return RecurrenceMicrostates(shape, expr, sampling, space)
 end
 
 

--- a/src/core/sampling.jl
+++ b/src/core/sampling.jl
@@ -49,6 +49,9 @@ struct RectSamplingSpace <: AbstractSamplingSpace end
 This sampling space defines that a recurrence microstate can be only retrived from
 the part ahead the line of identity of a recurrence plot. It means, \$ i < j \$ for
 \$ j \\leq K - N + 1\$.
+
+!!! compat "GPU"
+    Triangle sampling space is not available for GPU.
 """
 struct TriangleSamplingSpace <: AbstractSamplingSpace end
 

--- a/src/core/sampling.jl
+++ b/src/core/sampling.jl
@@ -1,4 +1,4 @@
-export SamplingMode, SamplingSpace
+export SamplingMode, AbstractSamplingSpace, RectSamplingSpace, TriangleSamplingSpace, ColumnSamplingSpace
 
 ##########################################################################################
 #   Sampling Mode
@@ -18,37 +18,92 @@ abstract type SamplingMode end
 ##########################################################################################
 #   Sampling Space
 ##########################################################################################
-"""
-    SamplingSpace
+abstract type InternalSamplingSpace end
 
-Define the range of valid indices used to sample the initial positions \$(i, j)\$ of microstates.
 """
-abstract type SamplingSpace end
+    AbstractSamplingSpace
+
+Abstract supertype defining from where the package must sample the initial positions
+\$(i, j)\$ of each microstate.
+
+# Implementations
+- [`RectSamplingSpace`](@ref)
+- [`TriangleSamplingSpace`](@ref)
+- [`ColumnSamplingSpace`](@ref)
+"""
+abstract type AbstractSamplingSpace end
 #.........................................................................................
-#   Based on time series: RP & CRP (CPU)
+#   Abstract sampling spaces
 #.........................................................................................
-struct SSRect2 <: SamplingSpace
+"""
+    RectSamplingSpace <: AbstractSamplingSpace
+
+This sampling space defines that a recurrence microstate can be retrived from the all
+possible indexes.
+"""
+struct RectSamplingSpace <: AbstractSamplingSpace end
+
+"""
+    TriangleSamplingSpace <: AbstractSamplingSpace
+
+This sampling space defines that a recurrence microstate can be only retrived from
+the part ahead the line of identity of a recurrence plot. It means, \$ i < j \$ for
+\$ j \\leq K - N + 1\$.
+"""
+struct TriangleSamplingSpace <: AbstractSamplingSpace end
+
+"""
+    ColumnSamplingSpace <: AbstractSamplingSpace
+
+This sampling space defines that a recurrence microstate can be only retrived from
+a specific column \$I\$. It means that \$ i = I \$ and \$ j \\in [1, K - N + 1] \$.
+
+# Constructor
+```julia
+ss = ColumnSamplingSpace(I)
+```
+
+Note that `I` must be lesser than `K - N + 1`, being `N` the microstate size.
+"""
+struct ColumnSamplingSpace <: AbstractSamplingSpace
+    I::Int
+end
+
+#.........................................................................................
+#   Internal sampling spaces
+#.........................................................................................
+struct SSRect2 <: InternalSamplingSpace
     W::Int
+    H::Int
+end
+
+struct SSRectN{D} <: InternalSamplingSpace
+    space::NTuple{D, Int}
+end
+
+struct SSTriangle <: InternalSamplingSpace
+    N::Int
+    L::Int
+end
+
+struct SSColumn <: InternalSamplingSpace
+    I::Int
     H::Int
 end
 #.........................................................................................
 SamplingSpace(
-    shape::MicrostateShape, 
+    shape::MicrostateShape,
+    abs::AbstractSamplingSpace,
     x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
     y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
-) = throw(ArgumentError("`SamplingSpace` not implemented for a microstate shape $(typeof(shape)), and input data types $(typeof(x)) for `x`, and $(typeof(y)) for `y`."))
-#.........................................................................................
-#   Based on spatial data: SRP & CSRP (CPU)
-#.........................................................................................
-struct SSRectN{D} <: SamplingSpace
-    space::NTuple{D, Int}
-end
-#.........................................................................................
+) = throw(ArgumentError("`InternalSamplingSpace` not implemented for a microstate shape $(typeof(shape)), abstract sampling space $(typeof(abs)), and input data types $(typeof(x)) for `x`, and $(typeof(y)) for `y`."))
+
 SamplingSpace(
     shape::MicrostateShape, 
+    abs::AbstractSamplingSpace,
     x::AbstractArray{<: Real}, 
     y::AbstractArray{<: Real}
-) = throw(ArgumentError("`SamplingSpace` not implemented for a microstate shape $(typeof(shape)), and input data types $(typeof(x)) for `x`, and $(typeof(y)) for `y`."))
+) = throw(ArgumentError("`InternalSamplingSpace` not implemented for a microstate shape $(typeof(shape)), abstract sampling space $(typeof(abs)), and input data types $(typeof(x)) for `x`, and $(typeof(y)) for `y`."))
 
 ##########################################################################################
 #   Implementation: sampling
@@ -56,7 +111,7 @@ SamplingSpace(
 function get_sample(
     core::RMACore,
     mode::SamplingMode,
-    space::SamplingSpace
+    space::InternalSamplingSpace
 )
     msg = "`get_sample` not implemented for core $(typeof(core)), sampling mode $(typeof(mode)), and sampling space $(typeof(space))"
     throw(ArgumentError(msg))
@@ -67,7 +122,7 @@ end
 ##########################################################################################
 function get_num_samples(
     mode::SamplingMode,
-    space::SamplingSpace
+    space::InternalSamplingSpace
 )
     msg = "`get_num_samples` not implemented for sampling mode $(typeof(mode)), and sampling space $(typeof(space))"
     throw(ArgumentError(msg))

--- a/src/sampling/full.jl
+++ b/src/sampling/full.jl
@@ -6,8 +6,8 @@ export Full
 """
     Full <: SamplingMode
 
-Sampling mode that selects **all** possible microstates within the
-[`SamplingSpace`](@ref).
+Sampling mode that selects **all** possible microstates with in the
+sampling space.
 
 #   Constructor
 ```julia
@@ -30,6 +30,24 @@ function get_sample(::CPUCore, ::Full, space::SSRect2, _, m)
 
     return i, j
 end
+
+function get_sample(::CPUCore, ::Full, space::SSTriangle, _, m)
+    S = space.L - 2 * space.N + 1
+
+    i = ceil(Int, ((2S + 1) - sqrt((2S + 1)^2 - 8m)) / 2)
+    A = (i - 1) * S - ((i - 1) * (i - 2)) ÷ 2
+    d = m - A - 1
+    j = i + space.N + d
+
+    return i, j
+end
+
+function get_sample(::CPUCore, ::Full, space::SSColumn, _, m)
+    i = space.I
+    j = m
+
+    return i, j
+end
 #.........................................................................................
 #   Based on time series: (GPU)
 #.........................................................................................
@@ -40,9 +58,22 @@ function get_sample(::GPUCore, ::Full, space::SSRect2, _, m)
     return i, j
 end
 
+function get_sample(::GPUCore, ::Full, space::SSTriangle, _, m)
+    throw("Triangle sampling space is not implemented for GPU when using full sampling mode.")
+end
+
+function get_sample(::GPUCore, ::Full, space::SSColumn, _, m)
+    i = space.I
+    j = m
+
+    return i, j
+end
+
 ##########################################################################################
 #   Implementations: Utils
 ##########################################################################################
 get_num_samples(::Full, space::SSRect2) = space.W * space.H
+get_num_samples(::Full, space::SSTriangle) = ((space.L - 2 * space.N + 1) * (space.L - 2 * space.N + 2)) ÷ 2
+get_num_samples(::Full, space::SSColumn) = space.H
 
 ##########################################################################################

--- a/src/sampling/random.jl
+++ b/src/sampling/random.jl
@@ -7,7 +7,7 @@ export SRandom
     SRandom{F<:Real} <: SamplingMode
 
 Sampling mode that randomly selects microstate positions \$(i, j)\$ within the
-[`SamplingSpace`](@ref).
+sampling space.
 
 #   Constructors
 ```julia
@@ -51,11 +51,40 @@ function get_sample(::CPUCore, ::SRandom, space::SSRect2, rng, _)
 
     return i, j
 end
+
+function get_sample(::CPUCore, ::SRandom, space::SSTriangle, rng, _)
+    a = ((space.L - 2 * space.N + 1) * (space.L - 2 * space.N + 2)) ÷ 2
+    m = rand(rng, 1:a)
+
+    S = space.L - 2 * space.N + 1
+
+    i = ceil(Int, ((2S + 1) - sqrt((2S + 1)^2 - 8m)) / 2)
+    A = (i - 1) * S - ((i - 1) * (i - 2)) ÷ 2
+    d = m - A - 1
+    j = i + space.N + d
+
+    return i, j
+end
+
+function get_sample(::CPUCore, ::SRandom, space::SSColumn, rng, _)
+    i = space.I
+    j = rand(rng, 1:space.H)
+
+    return i, j
+end
 #.........................................................................................
 #   Based on time series: (GPU)
 #.........................................................................................
 function get_sample(::GPUCore, ::SRandom, space::SSRect2, samples)
     return [@SVector[Int32(rand(1:space.W)), Int32(rand(1:space.H))] for _ in 1:samples]
+end
+
+function get_sample(::GPUCore, ::SRandom, space::SSTriangle, samples)
+    throw("Triangle sampling space is not implemented for GPU when using random sampling mode.")
+end
+
+function get_sample(::GPUCore, ::SRandom, space::SSColumn, samples)
+    return [@SVector[Int32(space.I), Int32(rand(1:space.H))] for _ in 1:samples]
 end
 #.........................................................................................
 #   Based on spatial data: (CPU only)
@@ -69,9 +98,12 @@ end
 #   Implementations: Utils
 ##########################################################################################
 get_num_samples(mode::SRandom{<:Integer}, ::SSRect2) = mode.sampling_factor
-get_num_samples(mode::SRandom{<:Real}, space::SSRect2) = ceil(Int, mode.sampling_factor * space.W * space.H)
-#.........................................................................................
 get_num_samples(mode::SRandom{<:Integer}, ::SSRectN) = mode.sampling_factor
+get_num_samples(mode::SRandom{<:Integer}, ::SSTriangle) = mode.sampling_factor
+get_num_samples(mode::SRandom{<:Integer}, ::SSColumn) = mode.sampling_factor
+#.........................................................................................
+get_num_samples(mode::SRandom{<:Real}, space::SSRect2) = ceil(Int, mode.sampling_factor * space.W * space.H)
 get_num_samples(mode::SRandom{<:Real}, space::SSRectN) = ceil(Int, mode.sampling_factor * reduce(*, space.space))
-
+get_num_samples(mode::SRandom{<:Real}, space::SSTriangle) = ceil(Int, mode.sampling_factor * ((space.L - 2 * space.N + 1) * (space.L - 2 * space.N + 2)) ÷ 2)
+get_num_samples(mode::SRandom{<:Real}, space::SSColumn) = ceil(Int, mode.sampling_factor * space.H)
 ##########################################################################################

--- a/src/shapes/diagonal.jl
+++ b/src/shapes/diagonal.jl
@@ -35,16 +35,16 @@ DiagonalMicrostate(N::Int; B::Int = 2) = DiagonalMicrostate{N, B}()
 ##########################################################################################
 #   Implementations: SamplingSpace
 ##########################################################################################
-#   Based on time series: (CPU & GPU)
-#.........................................................................................
 SamplingSpace(
     ::DiagonalMicrostate{N}, 
+    ::RectSamplingSpace,
     x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
     y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
 ) where {N} = SSRect2(length(x) - N + 1, length(y) - N + 1)
 
 function SamplingSpace(
     ::DiagonalMicrostate{N, B}, 
+    ::RectSamplingSpace,
     x::AbstractArray{<: Real}, 
     y::AbstractArray{<: Real}
 ) where {N, B}
@@ -56,6 +56,26 @@ function SamplingSpace(
     
     space = ntuple(i -> dims[i] - N, length(dims))
     return SSRectN{length(dims)}(space)
+end
+
+function SamplingSpace(
+    ::DiagonalMicrostate{N, B},
+    ::TriangleSamplingSpace,
+    x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
+    y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
+) where {N, B}
+    @assert length(x) == length(y) "Triangle sample space requires length(x) == length(y)."
+    return SSTriangle(N, length(x))
+end
+
+function SamplingSpace(
+    ::DiagonalMicrostate{N, B},
+    s::ColumnSamplingSpace,
+    x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
+    y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
+) where {N, B}
+    @assert 1 ≤ s.I ≤ length(x) - N + 1 "The column index is out of range."
+    return SSColumn(s.I, length(y) - N + 1)
 end
 
 ##########################################################################################

--- a/src/shapes/rect.jl
+++ b/src/shapes/rect.jl
@@ -70,18 +70,16 @@ end
 ##########################################################################################
 #   Implementations: SamplingSpace
 ##########################################################################################
-#   Based on time series: (CPU & GPU)
-#.........................................................................................
 SamplingSpace(
     ::Rect2Microstate{W, H}, 
+    ::RectSamplingSpace,
     x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
     y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
 ) where {W, H} = SSRect2(length(x) - W + 1, length(y) - H + 1)
-#.........................................................................................
-#   Based on spatial data: (CPU only)
-#.........................................................................................
+
 function SamplingSpace(
     shape::RectNMicrostate{D, B}, 
+    ::RectSamplingSpace,
     x::AbstractArray{<: Real}, 
     y::AbstractArray{<: Real}
 ) where {D, B}
@@ -95,6 +93,27 @@ function SamplingSpace(
     
     space = ntuple(i -> dims[i] - shape.structure[i] + 1, D)
     return SSRectN{D}(space)
+end
+
+function SamplingSpace(
+    ::Rect2Microstate{W, H},
+    ::TriangleSamplingSpace,
+    x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
+    y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
+) where {W, H}
+    @assert W == H "Triangle sampling space is not available for rectangular motifs."
+    @assert length(x) == length(y) "Triangle sampling space requires length(x) == length(y)."
+    return SSTriangle(W, length(x))
+end
+
+function SamplingSpace(
+    ::Rect2Microstate{W, H},
+    s::ColumnSamplingSpace,
+    x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
+    y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
+) where {W, H}
+    @assert 1 ≤ s.I ≤ length(x) - W + 1 "The column index is out of range."
+    return SSColumn(s.I, length(y) - H + 1)
 end
 
 ##########################################################################################

--- a/src/shapes/triangle.jl
+++ b/src/shapes/triangle.jl
@@ -35,9 +35,30 @@ TriangleMicrostate(N::Int; B::Int = 2) = TriangleMicrostate{N, B}()
 #.........................................................................................
 SamplingSpace(
     ::TriangleMicrostate{N}, 
+    ::RectSamplingSpace,
     x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
     y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
 ) where {N} = SSRect2(length(x) - N + 1, length(y) - N + 1)
+
+function SamplingSpace(
+    ::TriangleMicrostate{N},
+    ::TriangleSamplingSpace,
+    x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
+    y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
+) where {N}
+    @assert length(x) == length(y) "Triangle sample space requires length(x) == length(y)."
+    return SSTriangle(N, length(x))
+end
+
+function SamplingSpace(
+    ::TriangleMicrostate{N},
+    s::ColumnSamplingSpace,
+    x::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}, 
+    y::Union{StateSpaceSet, AbstractGPUVector{<: SVector}}
+) where {N}
+    @assert 1 ≤ s.I ≤ length(x) - N + 1 "The column index is out of range."
+    return SSColumn(s.I, length(y) - N + 1)
+end
 
 ##########################################################################################
 #   Implementations: utils — histogram size, power vector, and offsets

--- a/test/core.jl
+++ b/test/core.jl
@@ -30,10 +30,10 @@ end
 end
 
 @testset "Sampling structure" begin
-    @test_throws ArgumentError SamplingSpace(TestShape(), rand(100) |> StateSpaceSet, rand(100) |> StateSpaceSet)
-    @test_throws ArgumentError SamplingSpace(TestShape(), rand(2, 100), rand(2, 100))
+    @test_throws ArgumentError RecurrenceMicrostatesAnalysis.SamplingSpace(TestShape(), RectSamplingSpace(), rand(100) |> StateSpaceSet, rand(100) |> StateSpaceSet)
+    @test_throws ArgumentError RecurrenceMicrostatesAnalysis.SamplingSpace(TestShape(), RectSamplingSpace(), rand(2, 100), rand(2, 100))
 
-    space = SamplingSpace(RectMicrostate(2), rand(100) |> StateSpaceSet, rand(100) |> StateSpaceSet)
+    space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate(2), RectSamplingSpace(), rand(100) |> StateSpaceSet, rand(100) |> StateSpaceSet)
     @test_throws ArgumentError RecurrenceMicrostatesAnalysis.get_sample(RecurrenceMicrostatesAnalysis.CPUCore(), TestSampling(), space)
     @test_throws ArgumentError RecurrenceMicrostatesAnalysis.get_num_samples(TestSampling(), space)
 end

--- a/test/distributions.jl
+++ b/test/distributions.jl
@@ -13,6 +13,22 @@ using RecurrenceMicrostatesAnalysis
     @test abs(sum(probabilities(RecurrenceMicrostates(0.27, 3; ratio = 0.1, metric = Cityblock()), x)) - 1) <= 1e-3
     @test abs(sum(probabilities(RecurrenceMicrostates(0.27, 3; sampling = Full(), metric = Cityblock()), x)) - 1) <= 1e-3
 
+    @test abs(sum(probabilities(RecurrenceMicrostates(0.27, 3; ratio = 0.5, space = TriangleSamplingSpace()), x)) - 1) <= 1e-3
+    @test abs(sum(probabilities(RecurrenceMicrostates(0.27, DiagonalMicrostate(3); ratio = 0.5, space = TriangleSamplingSpace()), x)) - 1) <= 1e-3
+    @test abs(sum(probabilities(RecurrenceMicrostates(0.27, TriangleMicrostate(3); ratio = 0.5, space = TriangleSamplingSpace()), x)) - 1) <= 1e-3
+    @test abs(sum(probabilities(RecurrenceMicrostates(0.27, 3; space = TriangleSamplingSpace(), sampling = Full()), x)) - 1) <= 1e-3
+    @test abs(sum(probabilities(RecurrenceMicrostates(0.27, DiagonalMicrostate(3); space = TriangleSamplingSpace(), sampling = Full()), x)) - 1) <= 1e-3
+    @test abs(sum(probabilities(RecurrenceMicrostates(0.27, TriangleMicrostate(3); space = TriangleSamplingSpace(), sampling = Full()), x)) - 1) <= 1e-3
+
+    for i ∈ 1:(100 - 2)
+        @test abs(sum(probabilities(RecurrenceMicrostates(0.27, 3; ratio = 0.5, space = ColumnSamplingSpace(i)), x)) - 1) <= 1e-3
+        @test abs(sum(probabilities(RecurrenceMicrostates(0.27, DiagonalMicrostate(3); ratio = 0.5, space = ColumnSamplingSpace(i)), x)) - 1) <= 1e-3
+        @test abs(sum(probabilities(RecurrenceMicrostates(0.27, TriangleMicrostate(3); ratio = 0.5, space = ColumnSamplingSpace(i)), x)) - 1) <= 1e-3
+        @test abs(sum(probabilities(RecurrenceMicrostates(0.27, 3; space = ColumnSamplingSpace(i), sampling = Full()), x)) - 1) <= 1e-3
+        @test abs(sum(probabilities(RecurrenceMicrostates(0.27, DiagonalMicrostate(3); space = ColumnSamplingSpace(i), sampling = Full()), x)) - 1) <= 1e-3
+        @test abs(sum(probabilities(RecurrenceMicrostates(0.27, TriangleMicrostate(3); space = ColumnSamplingSpace(i), sampling = Full()), x)) - 1) <= 1e-3
+    end
+
     @test abs(sum(probabilities(RecurrenceMicrostates(ThresholdRecurrence(0.27), 3; sampling = Full()), x)) - 1) <= 1e-3
     @test abs(sum(probabilities(RecurrenceMicrostates(ThresholdRecurrence(0.27), 3; ratio = 0.1), x)) - 1) <= 1e-3
     @test abs(sum(probabilities(RecurrenceMicrostates(ThresholdRecurrence(0.27; metric = Cityblock()), 3; sampling = Full()), x)) - 1) <= 1e-3

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -12,7 +12,7 @@ using RecurrenceMicrostatesAnalysis
 
     @testset "num samples" begin
         data = rand(100) |> StateSpaceSet
-        space = SamplingSpace(RectMicrostate(2), data, data)
+        space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate(2), RectSamplingSpace(), data, data)
 
         @test RecurrenceMicrostatesAnalysis.get_num_samples(Full(), space) == space.W * space.H
         @test RecurrenceMicrostatesAnalysis.get_num_samples(Full(), space) isa Integer
@@ -22,7 +22,7 @@ using RecurrenceMicrostatesAnalysis
         @testset "CPU" begin
             data_1 = rand(50) |> StateSpaceSet
             data_2 = rand(20) |> StateSpaceSet
-            space = SamplingSpace(RectMicrostate(2), data_1, data_2)
+            space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate(2), RectSamplingSpace(), data_1, data_2)
             core = RecurrenceMicrostatesAnalysis.CPUCore()
 
             @test RecurrenceMicrostatesAnalysis.get_sample(core, Full(), space, nothing, 10) isa Tuple{<: Integer, <: Integer}
@@ -38,7 +38,7 @@ using RecurrenceMicrostatesAnalysis
         @testset "GPU" begin
             data_1 = rand(50) |> StateSpaceSet
             data_2 = rand(20) |> StateSpaceSet
-            space = SamplingSpace(RectMicrostate(2), data_1, data_2)
+            space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate(2), RectSamplingSpace(), data_1, data_2)
             core = RecurrenceMicrostatesAnalysis.GPUCore()
 
             @test RecurrenceMicrostatesAnalysis.get_sample(core, Full(), space, nothing, 10) isa Tuple{<: Integer, <: Integer}
@@ -70,7 +70,7 @@ end
     @testset "num samples" begin
         @testset "time series" begin
             data = rand(100) |> StateSpaceSet
-            space = SamplingSpace(RectMicrostate(2), data, data)
+            space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate(2), RectSamplingSpace(), data, data)
 
             sampling = SRandom(0.05)
             @test RecurrenceMicrostatesAnalysis.get_num_samples(sampling, space) == ceil(Int, sampling.sampling_factor * space.W * space.H)
@@ -83,7 +83,7 @@ end
         
         @testset "spatial data" begin
             data = rand(2, 100)
-            space = SamplingSpace(RectMicrostate((2, 2)), data, data)
+            space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate((2, 2)), RectSamplingSpace(), data, data)
 
             sampling = SRandom(0.05)
             @test RecurrenceMicrostatesAnalysis.get_num_samples(sampling, space) == ceil(Int, sampling.sampling_factor * reduce(*, space.space))
@@ -99,7 +99,7 @@ end
         @testset "CPU" begin
             data_1 = rand(50) |> StateSpaceSet
             data_2 = rand(20) |> StateSpaceSet
-            space = SamplingSpace(RectMicrostate(2), data_1, data_2)
+            space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate(2), RectSamplingSpace(), data_1, data_2)
             sampling = SRandom(50)
             core = RecurrenceMicrostatesAnalysis.CPUCore()
 
@@ -116,7 +116,7 @@ end
         @testset "GPU" begin
             data_1 = rand(50) |> StateSpaceSet
             data_2 = rand(20) |> StateSpaceSet
-            space = SamplingSpace(RectMicrostate(2), data_1, data_2)
+            space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate(2), RectSamplingSpace(), data_1, data_2)
             sampling = SRandom(50)
             core = RecurrenceMicrostatesAnalysis.GPUCore()
 
@@ -134,7 +134,7 @@ end
         @testset "spatial data" begin
             data_1 = rand(2, 50, 50)
             data_2 = rand(2, 20, 20)
-            space = SamplingSpace(RectMicrostate((2, 1, 1, 2)), data_1, data_2)
+            space = RecurrenceMicrostatesAnalysis.SamplingSpace(RectMicrostate((2, 1, 1, 2)), RectSamplingSpace(), data_1, data_2)
             sampling = SRandom(50)
             core = RecurrenceMicrostatesAnalysis.CPUCore()
 


### PR DESCRIPTION
This change is associated with issue #20.

I added a new setting to the `RecurrenceMicrostates` outcome space that specifies from which region of the recurrence plot the microstates should be retrieved. Strictly speaking, there is no actual recurrence plot being constructed, but this interpretation helps clarify how the process works.

Currently, there are three main implementations:

* `RectSamplingSpace`: considers the entire recurrence plot.
* `TriangleSamplingSpace`: considers only microstates above the LOI of the recurrence plot.
* `ColumnSamplingSpace`: considers only microstates from a specific column of the recurrence plot. This approach was used in works such as: https://doi.org/10.1103/PhysRevE.110.024203
