### PR TITLE
Fix complexity overwrite (see #35)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RecurrenceMicrostatesAnalysis"
 uuid = "cb83a08b-85c6-4e94-91aa-4e946c7d4f0c"
-version = "0.5.3"
+version = "0.5.4"
 repo = "https://github.com/JuliaDynamics/RecurrenceMicrostatesAnalysis.jl"
 authors = ["Gabriel V. Ferreira", "George Datseris"]
 

--- a/src/rqa/det.jl
+++ b/src/rqa/det.jl
@@ -82,7 +82,7 @@ struct RecurrenceDeterminism{M, SM} <: ComplexityEstimator
     sampling::SM
 end
 
-function complexity(
+function ComplexityMeasures.complexity(
         c::RecurrenceDeterminism, 
         x::Union{StateSpaceSet, Vector{<:Real}, <:AbstractGPUVector{<:SVector}}, 
         y::Union{StateSpaceSet, Vector{<:Real}, <:AbstractGPUVector{<:SVector}} = x;

--- a/src/rqa/disorder.jl
+++ b/src/rqa/disorder.jl
@@ -107,7 +107,7 @@ struct ClassPartialDisorder{RM <: RecurrenceMicrostates} <: ComplexityEstimator
     rmspace::RM
 end
 
-function complexity(
+function ComplexityMeasures.complexity(
         c::Disorder{N},
         x::Union{StateSpaceSet, Vector{<:Real}, <:AbstractGPUVector{<:SVector}}
     ) where {N}
@@ -139,7 +139,7 @@ function complexity(
     return maximum(ξ)
 end
 
-function complexity(
+function ComplexityMeasures.complexity(
         c::WindowedDisorder{W, N, M},
         x::Union{StateSpaceSet, Vector{<:Real}}
     ) where {N, W, M}
@@ -184,7 +184,7 @@ function complexity(
     return [ maximum(ξ[i, :]) for i ∈ eachindex(windowed_data) ]
 end
 
-function complexity(
+function ComplexityMeasures.complexity(
         c::WindowedDisorder{W, N},
         x::AbstractGPUVector{SVector{D, T}}
     ) where {N, W, D, T}
@@ -243,7 +243,7 @@ function complexity(
     return [ maximum(ξ[i, :]) for i ∈ eachindex(windowed_data) ]
 end
 
-function complexity(
+function ComplexityMeasures.complexity(
         c::PartialDisorder{N},
         x::Union{<: StateSpaceSet{D}, <:AbstractGPUVector{<: SVector{D}}}
     ) where {N, D}
@@ -254,7 +254,7 @@ function complexity(
     return measure(c, A, probs)
 end
 
-function complexity(
+function ComplexityMeasures.complexity(
         c::ClassPartialDisorder,
         x::Union{StateSpaceSet, <:AbstractGPUVector{<:SVector}}
     )

--- a/src/rqa/lam.jl
+++ b/src/rqa/lam.jl
@@ -82,7 +82,7 @@ struct RecurrenceLaminarity{M, SM} <: ComplexityEstimator
     sampling::SM
 end
 
-function complexity(
+function ComplexityMeasures.complexity(
         c::RecurrenceLaminarity, 
         x::Union{StateSpaceSet, Vector{<:Real}, <:AbstractGPUVector{<:SVector}}, 
         y::Union{StateSpaceSet, Vector{<:Real}, <:AbstractGPUVector{<:SVector}} = x;

--- a/src/rqa/rr.jl
+++ b/src/rqa/rr.jl
@@ -43,7 +43,7 @@ struct RecurrenceRate{N, M, SM} <: ComplexityEstimator
     sampling::SM
 end
 
-function complexity(
+function ComplexityMeasures.complexity(
         c::RecurrenceRate{N},
         x::Union{StateSpaceSet, Vector{<:Real}, <:AbstractGPUVector{<:SVector}}, 
         y::Union{StateSpaceSet, Vector{<:Real}, <:AbstractGPUVector{<:SVector}} = x;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using Aqua
+using ComplexityMeasures
 using RecurrenceMicrostatesAnalysis
 
 defaultname(file) = uppercasefirst(replace(splitext(basename(file))[1], '_' => ' '))


### PR DESCRIPTION
- Fix the complexity function overwrites.
- Add a `using ComplexityMeasures` to `runtests.jl` to check future overwrites.